### PR TITLE
Update docs and scripts for Google Colab

### DIFF
--- a/APTOS2025_OphNetCat_Guide.md
+++ b/APTOS2025_OphNetCat_Guide.md
@@ -36,9 +36,8 @@ frames are under `/content/drive/MyDrive/kaggle/APTOS/val2_videos/aptos_val2/fra
 The reference implementation is available at [APTOS2025_OphNet](https://github.com/minghu0830/APTOS2025_OphNet).
 Clone the repository and install the required packages:
 ```bash
-git clone https://github.com/minghu0830/APTOS2025_OphNet.git
-cd APTOS2025_OphNet
-pip install -r requirements.txt
+!git clone https://github.com/minghu0830/APTOS2025_OphNet.git /content/APTOS2025_OphNet
+!pip install -r /content/APTOS2025_OphNet/requirements.txt
 ```
 
 ## 3. Training
@@ -46,12 +45,12 @@ pip install -r requirements.txt
 1. The baseline repository expects the dataset in `APTOS2025_OphNet/dataset`.
    If your data lives elsewhere (e.g. on Google Drive), create a symbolic link or
    pass the absolute path when launching `train.py`:
-   ```bash
-   ln -s /content/drive/MyDrive/kaggle/APTOS APTOS2025_OphNet/dataset
-   # or
-   python train.py --cfg configs/cataract_phase.yaml \
-       --data /content/drive/MyDrive/kaggle/APTOS
-   ```
+```bash
+!ln -s /content/drive/MyDrive/kaggle/APTOS /content/APTOS2025_OphNet/dataset
+# or
+!python /content/APTOS2025_OphNet/train.py --cfg /content/APTOS2025_OphNet/configs/cataract_phase.yaml \
+    --data /content/drive/MyDrive/kaggle/APTOS
+```
    In `configs/cataract_phase.yaml` set the paths explicitly if needed:
    ```yaml
    data_root: /content/drive/MyDrive/kaggle/APTOS
@@ -65,7 +64,7 @@ pip install -r requirements.txt
 The script `train_features.py` trains a simple classifier using the pre-extracted VideoMAE features stored on Google Drive and directly generates predictions for `APTOS_val2.csv`.
 
 ```bash
-python train_features.py \
+!python /content/OphNet-benchmark/train_features.py \
   --annotation /content/drive/MyDrive/kaggle/APTOS/APTOS_train-val_annotation.csv \
   --features /content/drive/MyDrive/kaggle/APTOS/features_vmae224_b \
   --val2 /content/drive/MyDrive/kaggle/APTOS/APTOS_val2.csv \
@@ -77,7 +76,7 @@ Use the `--dry-run` flag to train only on the seven example videos listed above.
 
 After training, run inference on the validation set:
 ```bash
-python infer.py --cfg configs/cataract_phase.yaml --ckpt <path-to-checkpoint>
+!python /content/APTOS2025_OphNet/infer.py --cfg /content/APTOS2025_OphNet/configs/cataract_phase.yaml --ckpt <path-to-checkpoint>
 ```
 Append a new column named `Predict_phase_id` to `aptos_val2.csv` and fill in the predicted phase ID for each frame. Submit this CSV file.
 

--- a/README.md
+++ b/README.md
@@ -78,29 +78,28 @@ OphNet2024
 *  **Label Description**: The table with Chinese and English versions of surgery, phase, and operation names along with their ID mappings: [OphNet2024_Label](https://docs.google.com/spreadsheets/d/1p5lURkth587-lxYwd6eOSmSxPpvIqvyuOKW-4B49PT0/edit?usp=sharing)
 
 *  **HuggingFace Mirror** (optional, if you are in mainland China):
-    ```python
-    export HF_ENDPOINT=https://hf-mirror.com
+    ```bash
+    !export HF_ENDPOINT=https://hf-mirror.com
     ```
 
 * **Download All**:
-    ```python
-    huggingface-cli download --repo-type dataset --resume-download xioamiyh/OphNet2024 --revision main --local-dir ./
+    ```bash
+    !huggingface-cli download --repo-type dataset --resume-download xioamiyh/OphNet2024 --revision main --local-dir /content/OphNet-benchmark
     ```
 
-*  **Selective Download**: 
-    ```python
-    cd ./data_processing
-    bash ./download.sh
+*  **Selective Download**:
+    ```bash
+    !bash /content/OphNet-benchmark/data_processing/download.sh /content/OphNet-benchmark
     ```
 
 *  **Merge and Extract the Archive**:
-    ```python
-    cat OphNet2024_all.tar.gz.* | tar xzvf -
+    ```bash
+    !cat /content/OphNet-benchmark/OphNet2024_all.tar.gz.* | tar xzvf -
     ```
 
 *  **Skip Downloading Trimmed Video** (optional, trimming videos locally with the script):
-    ```python
-    python data_processing/cliper.py
+    ```bash
+    !python /content/OphNet-benchmark/data_processing/cliper.py
     ```
 
 ------------------------------------

--- a/baselines/task2/README.md
+++ b/baselines/task2/README.md
@@ -101,46 +101,40 @@ files (`medical_videomae_phase.yaml` and `medical_videomae_operation.yaml`).
 
 2. Install the required packages by running the following command:
 
-```shell
-pip install  -r requirements.txt
+```bash
+!pip install  -r /content/OphNet-benchmark/baselines/task2/requirements.txt
 ```
 
 3. Install NMS
 
-```shell
-cd ./libs/utils
-python setup.py install --user
-cd ../..
+```bash
+!python /content/OphNet-benchmark/baselines/task2/libs/utils/setup.py install --user
 ```
 
 4. Done! We are ready to get start!
 
 ## Prepare Datasets
 You can direct download the we have extracted
-```shell
-cd ./data_processing
-bash ./download.sh
+```bash
+!bash /content/OphNet-benchmark/data_processing/download.sh /content/OphNet-benchmark
 # set allow_patterns='Features/**'
 ```
 
 then put them into the dataset folder
 
 ```bash
-cd dataset/features
-ln -sT ~/path/to/feature_ophnet/feature ./videomae
+!ln -sT ~/path/to/feature_ophnet/feature /content/OphNet-benchmark/baselines/task2/dataset/features/videomae
 ```
 Or you can extract video features following below steps:
 
 1. Download videos from [OphNet2024](https://huggingface.co/datasets/xioamiyh/OphNet2024
 )
 ```bash
-cd dataset
-ln -sT ~/path/to/OphNet2024/OphNet2024_all ./videos 
+!ln -sT ~/path/to/OphNet2024/OphNet2024_all /content/OphNet-benchmark/baselines/task2/dataset/videos
 ```
 2. Extract the videomaev2 features
 ```bash
-cd backbone/videomaev2
-bash extract_dataset_feat.sh
+!bash /content/OphNet-benchmark/baselines/task2/backbone/videomaev2/extract_dataset_feat.sh
 ```
 
 ## Folder Stucture
@@ -172,29 +166,26 @@ We recommend using TriDet as the baseline due to its better performance.
 
 - train
 ```bash
-cd talnets/TriDet
-python train.py --config ./configs/medical_videomae_phase.yaml --output baseline
-python train.py --config ./configs/medical_videomae_operation.yaml --output baseline
+!python /content/OphNet-benchmark/baselines/task2/talnets/TriDet/train.py --config /content/OphNet-benchmark/baselines/task2/talnets/TriDet/configs/medical_videomae_phase.yaml --output baseline
+!python /content/OphNet-benchmark/baselines/task2/talnets/TriDet/train.py --config /content/OphNet-benchmark/baselines/task2/talnets/TriDet/configs/medical_videomae_operation.yaml --output baseline
 ```
 
 - eval
 ```bash
-python eval.py --config ./configs/medical_videomae_phase.yaml --ckpt ~/path/to/checkpoint
-python eval.py --config ./configs/medical_videomae_operation.yaml --ckpt ~/path/to/checkpoint
+!python /content/OphNet-benchmark/baselines/task2/talnets/TriDet/eval.py --config /content/OphNet-benchmark/baselines/task2/talnets/TriDet/configs/medical_videomae_phase.yaml --ckpt ~/path/to/checkpoint
+!python /content/OphNet-benchmark/baselines/task2/talnets/TriDet/eval.py --config /content/OphNet-benchmark/baselines/task2/talnets/TriDet/configs/medical_videomae_operation.yaml --ckpt ~/path/to/checkpoint
 ```
 
 - log
 ```bash
-cd ckpt
-tensorboard --logdir=./
+!tensorboard --logdir=/content/OphNet-benchmark/baselines/task2/ckpt
 ```
 
 - visualize
 ```bash
-python eval.py --config ./configs/medical_videomae_phase.yaml --ckpt ~/path/to/checkpoint --saveonly
-python eval.py --config ./configs/medical_videomae_operation.yaml --ckpt ~/path/to/checkpoint --saveonly
-cd ../tools
-python visualizer.py
+!python /content/OphNet-benchmark/baselines/task2/talnets/TriDet/eval.py --config /content/OphNet-benchmark/baselines/task2/talnets/TriDet/configs/medical_videomae_phase.yaml --ckpt ~/path/to/checkpoint --saveonly
+!python /content/OphNet-benchmark/baselines/task2/talnets/TriDet/eval.py --config /content/OphNet-benchmark/baselines/task2/talnets/TriDet/configs/medical_videomae_operation.yaml --ckpt ~/path/to/checkpoint --saveonly
+!python /content/OphNet-benchmark/baselines/task2/tools/visualizer.py
 
 ```
 
@@ -202,26 +193,23 @@ python visualizer.py
 
 - train
 ```bash
-cd talnets/actionformer
-python train.py --config ./configs/medical_videomae_phase.yaml --output baseline
-python train.py --config ./configs/medical_videomae_operation.yaml --output baseline
+!python /content/OphNet-benchmark/baselines/task2/talnets/actionformer/train.py --config /content/OphNet-benchmark/baselines/task2/talnets/actionformer/configs/medical_videomae_phase.yaml --output baseline
+!python /content/OphNet-benchmark/baselines/task2/talnets/actionformer/train.py --config /content/OphNet-benchmark/baselines/task2/talnets/actionformer/configs/medical_videomae_operation.yaml --output baseline
 ```
 
 - eval
 ```bash
-python eval.py --config ./configs/medical_videomae_phase.yaml --ckpt ~/path/to/checkpoint
-python eval.py --config ./configs/medical_videomae_operation.yaml --ckpt ~/path/to/checkpoint
+!python /content/OphNet-benchmark/baselines/task2/talnets/actionformer/eval.py --config /content/OphNet-benchmark/baselines/task2/talnets/actionformer/configs/medical_videomae_phase.yaml --ckpt ~/path/to/checkpoint
+!python /content/OphNet-benchmark/baselines/task2/talnets/actionformer/eval.py --config /content/OphNet-benchmark/baselines/task2/talnets/actionformer/configs/medical_videomae_operation.yaml --ckpt ~/path/to/checkpoint
 ```
 
 - log
 ```bash
-cd ckpt
-tensorboard --logdir=./
+!tensorboard --logdir=/content/OphNet-benchmark/baselines/task2/ckpt
 ```
 
 ## Checkpoint
-```shell
-cd ./data_processing
-bash ./download.sh
+```bash
+!bash /content/OphNet-benchmark/data_processing/download.sh /content/OphNet-benchmark
 # set allow_patterns='Checkpoints/**'
 ```

--- a/baselines/task2/talnets/TriDet/README.md
+++ b/baselines/task2/talnets/TriDet/README.md
@@ -42,10 +42,8 @@ pip install  -r requirements.txt
 
 3. Install NMS
 
-```shell
-cd ./libs/utils
-python setup.py install --user
-cd ../..
+```bash
+!python /content/OphNet-benchmark/baselines/task2/talnets/TriDet/libs/utils/setup.py install --user
 ```
 
 4. Done! We are ready to get start!

--- a/baselines/task2/talnets/actionformer/INSTALL.md
+++ b/baselines/task2/talnets/actionformer/INSTALL.md
@@ -16,10 +16,8 @@
 
 Part of NMS is implemented in C++. The code can be compiled by
 
-```shell
-cd ./libs/utils
-python setup.py install --user
-cd ../..
+```bash
+!python /content/OphNet-benchmark/baselines/task2/talnets/actionformer/libs/utils/setup.py install --user
 ```
 
 The code should be recompiled every time you update PyTorch.

--- a/data_processing/download.sh
+++ b/data_processing/download.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 #  allow_patterns: OphNet2024_all,OphNet2024_trimmed_operation,OphNet2024_trimmed_phase,Features,Checkpoints
-python -c "
+
+TARGET_DIR=${1:-$(pwd)}
+
+python - "$TARGET_DIR" <<'PY'
+import sys
 from huggingface_hub import snapshot_download
 
 snapshot_download(
@@ -23,8 +27,8 @@ snapshot_download(
 
     # allow_patterns='Features/**',
 
-    local_dir='./'
+    local_dir=sys.argv[1]
 )
-"
+PY
 
 echo "✅ Download complete"


### PR DESCRIPTION
## Summary
- modify download script to accept destination directory
- update README instructions with Colab-friendly commands
- adjust APTOS2025 guide for absolute paths
- clean up baseline README examples for Colab usage
- update INSTALL notes for ActionFormer and TriDet

## Testing
- `bash -n data_processing/download.sh`