### PR TITLE
Add build instructions for C++ NMS

### DIFF
--- a/APTOS2025_OphNetCat_Guide.md
+++ b/APTOS2025_OphNetCat_Guide.md
@@ -37,6 +37,7 @@ Clone this repository and install the required packages using the requirements f
 ```bash
 !git clone https://github.com/hida1211/OphNet-benchmark.git /content/OphNet-benchmark
 !pip install -r /content/OphNet-benchmark/baselines/task2/requirements.txt
+!python /content/OphNet-benchmark/setup.py build_ext --inplace
 ```
 
 ## 3. Training

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Clone this repository and move into the working directory:
 All commands below assume the code lives in `/content/OphNet-benchmark`.
 
 ------------------------------------
+## Installation
+
+Install the required Python packages and compile the C++ extension:
+
+```bash
+!pip install -r /content/OphNet-benchmark/baselines/task2/requirements.txt
+!python /content/OphNet-benchmark/setup.py build_ext --inplace
+```
+
+The second command builds the `nms_1d_cpu` module used by the temporal
+localization baselines. Re-run it whenever PyTorch is upgraded.
+
+------------------------------------
 ## Dataset Preparation
 ### Directory Structure
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+setup(
+    name="ophnet",
+    packages=find_packages(),
+    ext_modules=[
+        CppExtension(
+            name="nms_1d_cpu",
+            sources=[
+                "baselines/task2/talnets/TriDet/libs/utils/csrc/nms_cpu.cpp"
+            ],
+            extra_compile_args=["-fopenmp"],
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)


### PR DESCRIPTION
## Summary
- provide new `setup.py` for compiling `nms_1d_cpu`
- document installation steps in README
- update APTOS2025 guide with build command

## Testing
- `python setup.py build_ext --inplace` *(fails: ModuleNotFoundError: No module named 'torch')*