### PR TITLE
Fix path resolution for C++ extension build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include baselines/task2/talnets/TriDet/libs/utils/csrc/nms_cpu.cpp
+include baselines/task2/talnets/actionformer/libs/utils/csrc/nms_cpu.cpp

--- a/baselines/task2/talnets/TriDet/libs/utils/setup.py
+++ b/baselines/task2/talnets/TriDet/libs/utils/setup.py
@@ -1,15 +1,18 @@
 import torch
+from pathlib import Path
 
 from setuptools import setup, Extension
 from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+ROOT = Path(__file__).resolve().parent
 
 
 setup(
     name='nms_1d_cpu',
     ext_modules=[
         CppExtension(
-            name = 'nms_1d_cpu',
-            sources = ['./csrc/nms_cpu.cpp'],
+            name='nms_1d_cpu',
+            sources=[str(ROOT / 'csrc' / 'nms_cpu.cpp')],
             extra_compile_args=['-fopenmp']
         )
     ],

--- a/baselines/task2/talnets/actionformer/libs/utils/setup.py
+++ b/baselines/task2/talnets/actionformer/libs/utils/setup.py
@@ -1,15 +1,18 @@
 import torch
+from pathlib import Path
 
 from setuptools import setup, Extension
 from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+ROOT = Path(__file__).resolve().parent
 
 
 setup(
     name='nms_1d_cpu',
     ext_modules=[
         CppExtension(
-            name = 'nms_1d_cpu',
-            sources = ['./csrc/nms_cpu.cpp'],
+            name='nms_1d_cpu',
+            sources=[str(ROOT / 'csrc' / 'nms_cpu.cpp')],
             extra_compile_args=['-fopenmp']
         )
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
+from pathlib import Path
 from setuptools import setup, find_packages
 from torch.utils.cpp_extension import BuildExtension, CppExtension
+
+ROOT = Path(__file__).resolve().parent
 
 setup(
     name="ophnet",
@@ -8,7 +11,7 @@ setup(
         CppExtension(
             name="nms_1d_cpu",
             sources=[
-                "baselines/task2/talnets/TriDet/libs/utils/csrc/nms_cpu.cpp"
+                str(ROOT / "baselines/task2/talnets/TriDet/libs/utils/csrc/nms_cpu.cpp")
             ],
             extra_compile_args=["-fopenmp"],
         )


### PR DESCRIPTION
## Summary
- include nms sources in manifest
- resolve paths to C++ sources relative to setup scripts

## Testing
- `python -m py_compile setup.py baselines/task2/talnets/TriDet/libs/utils/setup.py baselines/task2/talnets/actionformer/libs/utils/setup.py`