### PR TITLE
Fix dataset path resolution

### DIFF
--- a/baselines/task2/README.md
+++ b/baselines/task2/README.md
@@ -137,6 +137,12 @@ Or you can extract video features following below steps:
 !bash /content/OphNet-benchmark/baselines/task2/backbone/videomaev2/extract_dataset_feat.sh
 ```
 
+If you already have your own features and annotation files, update the
+`json_file` and `feat_folder` fields in the YAML configuration files with the
+absolute paths to your data. Relative paths are resolved with respect to the
+configuration file location, so providing absolute paths allows placing the data
+anywhere on your system.
+
 ## Folder Stucture
 
 Check you folder stucture, it should be like:

--- a/baselines/task2/talnets/actionformer/libs/core/config.py
+++ b/baselines/task2/talnets/actionformer/libs/core/config.py
@@ -157,4 +157,18 @@ def load_config(config_file, defaults=DEFAULTS):
         config = yaml.load(fd, Loader=yaml.FullLoader)
     _merge(defaults, config)
     config = _update_config(config)
+
+    # convert dataset paths to absolute paths so that the training script can be
+    # executed from any working directory. Paths in the config are specified
+    # relative to the configuration file location.
+    cfg_dir = os.path.dirname(os.path.abspath(config_file))
+    action_root = os.path.dirname(cfg_dir)
+    for key in ["json_file", "feat_folder"]:
+        if key in config.get("dataset", {}):
+            p = config["dataset"][key]
+            if not os.path.isabs(p):
+                config["dataset"][key] = os.path.abspath(
+                    os.path.join(action_root, p)
+                )
+
     return config


### PR DESCRIPTION
## Summary
- ensure ActionFormer config parser resolves dataset paths relative to the config file
- document how to use custom data by editing paths in the YAML configs

## Testing
- `python -m py_compile baselines/task2/talnets/actionformer/libs/core/config.py baselines/task2/talnets/TriDet/libs/core/config.py`
