### PR TITLE
Update installation instructions for Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,21 @@ Clone this repository and move into the working directory:
 ```
 All commands below assume the code lives in `/content/OphNet-benchmark`.
 
+### Prerequisites
+
+This project has been tested with **Python 3.11** and **PyTorch 2.6**
+(CUDA 12.4). Install PyTorch first (replace the URL if you prefer the CPU
+build):
+
+```bash
+pip install torch==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu124
+```
+
 ------------------------------------
 ## Installation
 
-Install the required Python packages and compile the C++ extension:
+After installing PyTorch, install the remaining Python packages and compile the
+C++ extension:
 
 ```bash
 !pip install -r /content/OphNet-benchmark/baselines/task2/requirements.txt


### PR DESCRIPTION
## Summary
- mention Python 3.11 and torch 2.6 in README
- clarify installing torch before requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841942faf148331af6404d2e22c06f8