### PR TITLE
Add fps mapping support

### DIFF
--- a/APTOS2025_OphNetCat_Guide.md
+++ b/APTOS2025_OphNetCat_Guide.md
@@ -63,7 +63,8 @@ Clone this repository and install the required packages using the requirements f
 ```bash
 !python /content/OphNet-benchmark/data_processing/csv_to_tridet_json.py \
   --csv /content/drive/MyDrive/kaggle/APTOS/APTOS_train-val_annotation.csv \
-  --out /content/OphNet-benchmark/baselines/task2/dataset/tal_annotations/OphNet2024_phase.json
+  --out /content/OphNet-benchmark/baselines/task2/dataset/tal_annotations/OphNet2024_phase.json \
+  --fps-csv /content/drive/MyDrive/kaggle/APTOS/meta/video_fps.csv
 ```
 
 3. Alternatively, you can train the ActionFormer baseline:

--- a/data_processing/csv_to_tridet_json.py
+++ b/data_processing/csv_to_tridet_json.py
@@ -1,11 +1,14 @@
 import argparse
 import json
-from collections import defaultdict
 import pandas as pd
 
 
-def convert(csv_path, json_path, default_fps=30):
+def convert(csv_path, json_path, default_fps=30, fps_csv=None):
     df = pd.read_csv(csv_path)
+    fps_lookup = None
+    if fps_csv:
+        fps_df = pd.read_csv(fps_csv)
+        fps_lookup = dict(zip(fps_df["file"], fps_df["fps"]))
     database = {}
     labels = sorted(df['phase_id'].unique())
     for vid, group in df.groupby('video_id'):
@@ -20,7 +23,7 @@ def convert(csv_path, json_path, default_fps=30):
             })
         database[vid] = {
             'subset': subset,
-            'fps': default_fps,
+            'fps': fps_lookup.get(vid, default_fps) if fps_lookup else default_fps,
             'duration': duration,
             'annotations': annotations
         }
@@ -34,9 +37,10 @@ def main():
     parser = argparse.ArgumentParser(description='Convert CSV annotations to TriDet JSON format')
     parser.add_argument('--csv', required=True, help='annotation csv file')
     parser.add_argument('--out', required=True, help='output json file')
-    parser.add_argument('--fps', type=float, default=30, help='fps value to store in json')
+    parser.add_argument('--fps', type=float, default=30, help='default fps value to store in json')
+    parser.add_argument('--fps-csv', help='optional CSV mapping file,fps')
     args = parser.parse_args()
-    convert(args.csv, args.out, args.fps)
+    convert(args.csv, args.out, args.fps, args.fps_csv)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow mapping custom fps per video when converting CSV annotation to TriDet JSON
- document using `--fps-csv` argument for APTOS2025 dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197c884b08331b81b6ded2d3886f8