### PR TITLE
Add evaluation script

### DIFF
--- a/APTOS2025_OphNetCat_Guide.md
+++ b/APTOS2025_OphNetCat_Guide.md
@@ -119,3 +119,18 @@ The official metrics are:
 
 See the challenge description for full details of how TP, FP and FN are computed.
 
+## 7. Evaluating Predictions
+
+After generating a CSV containing a `Predict_phase_id` column, you can compute
+the official metrics locally using `evaluate_predictions.py`:
+
+```bash
+python evaluate_predictions.py \
+  --annotation /content/drive/MyDrive/kaggle/APTOS/APTOS_train-val_annotation.csv \
+  --pred pred_val2.csv \
+  --out metrics.json
+```
+
+The script prints the Rank Score and saves all metrics to the specified output
+file.
+

--- a/evaluate_predictions.py
+++ b/evaluate_predictions.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+import pandas as pd
+from sklearn.metrics import precision_recall_fscore_support
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate phase predictions")
+    parser.add_argument("--annotation", required=True, help="CSV with ground truth phase labels")
+    parser.add_argument("--pred", required=True, help="CSV with predicted phase labels")
+    parser.add_argument("--out", default="metrics.json", help="File to save computed metrics")
+    args = parser.parse_args()
+
+    ann = pd.read_csv(args.annotation)
+    pred = pd.read_csv(args.pred)
+
+    video_col = "Video_name" if "Video_name" in ann.columns else "video_id"
+    frame_col = "Frame_id" if "Frame_id" in ann.columns else "frame"
+    label_col = "Phase_id" if "Phase_id" in ann.columns else "phase_id"
+    pred_col = "Predict_phase_id" if "Predict_phase_id" in pred.columns else "predict_phase_id"
+
+    df = ann[[video_col, frame_col, label_col]].merge(
+        pred[[video_col, frame_col, pred_col]],
+        on=[video_col, frame_col],
+        how="inner",
+    )
+
+    acc_per_video = df.groupby(video_col).apply(
+        lambda g: (g[label_col] == g[pred_col]).mean()
+    )
+    video_accuracy = acc_per_video.mean() if len(acc_per_video) else 0.0
+
+    precision, recall, f1, _ = precision_recall_fscore_support(
+        df[label_col],
+        df[pred_col],
+        labels=list(range(35)),
+        average="macro",
+        zero_division=0,
+    )
+
+    rank_score = (video_accuracy + f1) / 2
+
+    metrics = {
+        "video_accuracy": video_accuracy,
+        "macro_precision": precision,
+        "macro_recall": recall,
+        "macro_f1": f1,
+        "rank_score": rank_score,
+    }
+
+    print(f"Rank Score: {rank_score:.4f}")
+    with open(args.out, "w") as f:
+        json.dump(metrics, f, indent=2)
+    print(f"Saved metrics to {args.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `evaluate_predictions.py` for computing accuracy, macro metrics and Rank Score
- document how to run the evaluator in the APTOS2025 usage guide

## Testing
- `pip install pandas scikit-learn --quiet`
- `python evaluate_predictions.py --help`
- run the script on sample data

------
https://chatgpt.com/codex/tasks/task_e_684197ca7b6c8331adbd737bf6e8f19e